### PR TITLE
Prepare v1.1.0 release: changelog, docs, version bumps and link fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.1.0] 2025-07-20
+## [Unreleased]
 
-### Added FolloWing Color Patteles
+### Planned
+- Dark mode utilities
+- Animation library expansion
+- Component library
+- Figma design system
+- VS Code extension
+- CLI tool for customization
+
+## [1.1.0] - 2025-07-20
+
+### Added following color palettes
 - `மயில்பச்சை` (Teal) - 50 to 900 shades
 - `நீர்நிறம்` (Cyan) - 50 to 900 shades
 - `மரகதம்` (Emerald) - 50 to 900 shades
@@ -56,13 +66,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Firefox 85+
 - Safari 14+
 - Edge 88+
-
-## [Unreleased]
-
-### Planned
-- Dark mode utilities
-- Animation library expansion
-- Component library
-- Figma design system
-- VS Code extension
-- CLI tool for customization

--- a/README.md
+++ b/README.md
@@ -207,4 +207,4 @@ For detailed documentation, visit: [Documentation](https://github.com/Aruvili/az
 
 - GitHub Issues: [Report bugs or request features](https://github.com/Aruvili/azhivili-css/issues)
 - Discussions: [Community discussions](https://github.com/Aruvili/azhivili-css/discussions)
-- Discord [Discord discussion](https://discord.gg/CcsRe8gWRV)
+- Discord: [Discord discussion](https://discord.gg/CcsRe8gWRV)

--- a/azhivili/main.scss
+++ b/azhivili/main.scss
@@ -27,8 +27,8 @@
 
 // Framework Information
 /*! 
- * அழிவிலி-CSS Framework v1.0.0
- * அழிவிலி-CSS கட்டமைப்பு v1.0.0
+ * அழிவிலி-CSS Framework v1.1.0
+ * அழிவிலி-CSS கட்டமைப்பு v1.1.0
  * 
  * A comprehensive utility-first CSS framework with Tamil class names
  * தமிழ் வகுப்பு பெயர்களுடன் கூடிய விரிவான பயன்பாட்டு-முதல் CSS கட்டமைப்பு

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     
     <!-- CSS Framework -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Aruvili/Azhivili-CSS@master/dist/azhivili-css.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/azhivili-css@1.1.0/dist/azhivili-css.min.css">
     
     <!-- Custom Documentation Styles -->
     <style>
@@ -54,7 +54,7 @@
             <div class="கா-நெகிழ் நியஉ-இடையே உசீ-மையம்">
                 <div class="கா-நெகிழ் உசீ-மையம் கஇ-2">
                     <h1 class="எஅ-மிபெ எஎ-தடிமன் நி-சாம்பல்-900">அழிவிலி-CSS</h1>
-                    <span class="எஅ-சி நி-சாம்பல்-600">v1.0.0</span>
+                    <span class="எஅ-சி நி-சாம்பல்-600">v1.1.0</span>
                 </div>
                 
                 <div class="கா-நெகிழ் கஇ-6">
@@ -108,7 +108,7 @@
                 <div class="பி-வெள்ளை ப-6 எவள்-பெ நிபெ-சி">
                     <h3 class="எஅ-மிபெ எஎ-அரைதடிமன் ம-கீ-4">CDN</h3>
                     <div class="code-block ப-4 எவள்-நடு">
-                        <code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/azhivili-css@latest/dist/azhivili-css.min.css"&gt;</code>
+                        <code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/azhivili-css@1.1.0/dist/azhivili-css.min.css"&gt;</code>
                     </div>
                 </div>
                 
@@ -173,7 +173,7 @@
                 <!-- Live Example -->
                 <div class="ம-கீ-6">
                     <div class="அதிஅ-சி பி-வெள்ளை நிபெ-பெ எவள்-பெ பெருக்கம்-மறைக்கப்பட்ட">
-                        <img src="/placeholder.svg?height=200&width=400" alt="Demo" class="அ-முழு உ-48 பி-சாம்பல்-200">
+                        <img src="https://via.placeholder.com/400x200" alt="Demo" class="அ-முழு உ-48 பி-சாம்பல்-200">
                         <div class="ப-6">
                             <h4 class="எஅ-பெ எஎ-அரைதடிமன் ம-கீ-2">அழிவிலி-CSS Card</h4>
                             <p class="நி-சாம்பல்-600 ம-கீ-4">This is a sample card built with அழிவிலி-CSS Framework utilities.</p>
@@ -213,9 +213,9 @@
                 <div>
                     <h4 class="எஎ-அரைதடிமன் ம-கீ-4">Resources</h4>
                     <ul class="கஇ-2">
-                        <li><a href="#" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Documentation</a></li>
-                        <li><a href="#" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Examples</a></li>
-                        <li><a href="#" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Playground</a></li>
+                        <li><a href="#get-started" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Documentation</a></li>
+                        <li><a href="#examples" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Examples</a></li>
+                        <li><a href="https://github.com/Aruvili/azhivili-css/discussions" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Playground</a></li>
                     </ul>
                 </div>
                 
@@ -223,8 +223,8 @@
                     <h4 class="எஎ-அரைதடிமன் ம-கீ-4">Community</h4>
                     <ul class="கஇ-2">
                         <li><a href="https://github.com/Aruvili/azhivili-css" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">GitHub</a></li>
-                        <li><a href="#" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Discord</a></li>
-                        <li><a href="#" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Twitter</a></li>
+                        <li><a href="https://discord.gg/CcsRe8gWRV" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Discord</a></li>
+                        <li><a href="https://github.com/Aruvili/azhivili-css/discussions" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Discussions</a></li>
                     </ul>
                 </div>
                 
@@ -233,7 +233,7 @@
                     <ul class="கஇ-2">
                         <li><a href="https://github.com/Aruvili/azhivili-css/issues" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Issues</a></li>
                         <li><a href="https://github.com/Aruvili/azhivili-css/discussions" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Discussions</a></li>
-                        <li><a href="#" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Contributing</a></li>
+                        <li><a href="https://github.com/Aruvili/azhivili-css/blob/main/CONTRIBUTING.md" class="நி-சாம்பல்-400 மேல்:நி-வெள்ளை">Contributing</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
### Motivation
- Prepare the project for a `v1.1.0` release by updating version strings and release notes. 
- Provide a top-level `Unreleased` section with planned features for tracking upcoming work. 
- Ensure documentation and CDN references point to the new release and improve several doc assets and links. 

### Description
- Updated `CHANGELOG.md` to add a `## [Unreleased]` section with a `Planned` list and corrected the "Added following color palettes" heading. 
- Bumped the framework version strings to `v1.1.0` in `azhivili/main.scss`. 
- Updated `docs/index.html` to pin CDN references to `@1.1.0`, change the displayed site version to `v1.1.0`, replace a local placeholder image with a stable external placeholder URL, and fix several footer/navigation links to real anchors and community pages. 
- Minor README formatting fix for the Discord link. 

### Testing
- No automated tests were run for these documentation and metadata changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7de2e5194832bb0adaad1fb4eff3e)